### PR TITLE
Adds documentation and support for multiple tools on the build tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# rv-metadata-plugin
-This is a plugin that allows the user to copy certain metadata from an image in RV image and sequence viewer
+# RV Shotgun plugin to copy metadata
+This is a plugin that allows the user to copy certain metadata from an image in RV.
+[RV](https://www.shotgunsoftware.com/rv) is an image, audio and video review software owned by Shotgun.
+
+### Usage
+
+The plugin finds information in the image metadata for a contact-sheet in which each quadrant corresponds to a location 
+on disk where the original is stored.
+
+It was written to help a client with a particular need. Given a contact-sheet with different clips rendered as JPEG 
+sequence, the metadata contains a list of the locations of the original clips on disk
+as well as the coordinates in pixels of each clip on the image. The plugin takes the location
+of the mouse pointer and matches it to the location on disk copying to the clipboard.
+
+#### Requirements
+
+* RV-2021.0.0
+
+### Installation
+
+1. Clone repo
+2. Zip and install plugin:
+    * Using the `build-tool` (currently only works on Windows):
+    ```bash
+    python3 build-tool.py --install
+    ```
+3. Open RV
+4. Open contact sheet sequence
+5. Middle mouse click in the desired part of the clip to copy location to 
+
+#### Tools used and compatible versions
+
+* Written in Python 3
+* Tested with RV-2021.0.0
+* Uses Pyside2 to copy the data to the clipboard
+* Plugin runs in Windows, Mac and Linux

--- a/build-tool.py
+++ b/build-tool.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """
-This is a script to assist with RV's package development in order to iterate and deploy easily
+This is a script to assist with RV's package development in order to iterate and deploy easily.
+It searches inside the 'plugin' folder and adds the contents to a zip ".rvpkg" file.
+It can then install and add the rvpkg to the RV installation.
+It can start/restart RV to pick up the latest changes.
 """
 
 __author__ = "Gabriela Roque Lopez"
@@ -130,8 +133,8 @@ def main(args):
 
 
 if __name__ == "__main__":
-    """ This is executed when run from the command line """
-    parser = argparse.ArgumentParser()
+
+    parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument("-b", "--build",
                         action="store_true",
@@ -153,12 +156,7 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--test",
                         action="store_true",
                         default=False,
-                        help="Run unit tests for plugin, defaults to False")
-
-    parser.add_argument("-v", "--verbose",
-                        action="count",
-                        default=0,
-                        help="Verbosity (-v, -vv, etc)")
+                        help="Run unit tests for plugin, defaults to False. NOT IMPLEMENTED")
 
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
This change looks bigger than it is because the `build-tool.py` file formatting broke when I changed the docstring.

Changes to build-tool:
* Adds documentation for the script
* Removes verbosity flag that were not being used or comments on test to implement in the future
* Adds support to build and install in MacOs and Linux

Changes to Readme:
* Adds basic documentation for the plugin